### PR TITLE
Fix PWM crash when duty cycle exceeds range

### DIFF
--- a/clientrobotpi.js
+++ b/clientrobotpi.js
@@ -796,8 +796,10 @@ function setServos(n, value) {
 function setPwm(n, gpio, pwm) {
  let pcaId = hard.OUTPUTS[n].ADRESSE;
 
- if(pcaId == SYS.UNUSED)
-  gpioOutputs[n][gpio].pwmWrite(Math.abs(map(pwm, -100, 100, -255, 255)));
+ if(pcaId == SYS.UNUSED) {
+  let range = gpioOutputs[n][gpio].getPwmRange();
+  gpioOutputs[n][gpio].pwmWrite(Math.min(range, Math.abs(map(pwm, -100, 100, -range, range))));
+ }
  else
   pca9685Driver[pcaId].setDutyCycle(hard.OUTPUTS[n].GPIOS[gpio], Math.abs(pwm / 100));
 }


### PR DESCRIPTION
## Summary

- When `pwmFrequency()` is called, pigpio changes the valid PWM range based on the clock divider (`real_range = 19.2MHz / frequency`). The current code hardcodes `255` as the range in `setPwm()`, which can exceed the actual valid range, causing pigpio to throw a fatal `gpioPWM: bad dutycycle` error that crashes the Node.js process.
- This creates a crash loop where the client connects to the server, receives configuration, crashes on the PWM init, restarts, and repeats — making it impossible to fix the configuration remotely.
- Uses `getPwmRange()` to dynamically determine the valid range and clamps the duty cycle value accordingly.

## Reproduction

1. Configure a robot on vigibot.com with a high `PWMFREQUENCY` or output mapping that produces values outside the expected range
2. The client crashes repeatedly with: `gpioPWM: gpio XX, bad dutycycle (YYYY)`
3. The robot becomes unreachable via vigibot.com, preventing remote configuration fixes

## Changes

`clientrobotpi.js` line 800 in `setPwm()`:

```js
// Before:
gpioOutputs[n][gpio].pwmWrite(Math.abs(map(pwm, -100, 100, -255, 255)));

// After:
let range = gpioOutputs[n][gpio].getPwmRange();
gpioOutputs[n][gpio].pwmWrite(Math.min(range, Math.abs(map(pwm, -100, 100, -range, range))));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)